### PR TITLE
Ensure innCulture applies once in knowledge quarry variant

### DIFF
--- a/cozy_settlement/cozy_chief_v2_7_knowledge_quarry.html
+++ b/cozy_settlement/cozy_chief_v2_7_knowledge_quarry.html
@@ -401,7 +401,6 @@ function updateBuildButtons(){
 function prodMult(b){
   let m = S.mods.allMult;
   if(b.k==='woodhut') m*=S.mods.woodhutMult;
-  if(b.k==='inn') m*=S.mods.innCulture; // handled in culture
   return m;
 }
 function produce(dtMinutes){


### PR DESCRIPTION
## Summary
- Remove innCulture multiplier from prodMult to prevent double counting
- Culture output from inns now uses the modifier only once

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af416781688333884814fbde14272d