### PR TITLE
Hide highlight when leaving placement mode

### DIFF
--- a/cozy_settlement/cozy_chief_v2_7_knowledge_quarry.html
+++ b/cozy_settlement/cozy_chief_v2_7_knowledge_quarry.html
@@ -281,6 +281,7 @@ function enterPlacement(k){
 }
 function exitPlacement(msg){
   S.place=null; $('#placingText').textContent=''; if(msg) $('#planner').textContent=msg;
+  hl.style.display='none';
 }
 
 // ===== Map & camera


### PR DESCRIPTION
## Summary
- Hide tile highlight on exiting placement mode in cozy chief v2.7 knowledge quarry to avoid lingering highlight

## Testing
- `node - <<'NODE'
let S={};
let hl={style:{display:'block'}};
let placingText={textContent:'placing'};
let planner={textContent:'plan'};
function $(selector){
  if(selector==='#placingText') return placingText;
  if(selector==='#planner') return planner;
  return {};
}
function exitPlacement(msg){
  S.place=null; $('#placingText').textContent=''; if(msg) $('#planner').textContent=msg;
  hl.style.display='none';
}
console.log('before', hl.style.display);
exitPlacement();
console.log('after', hl.style.display);
NODE`
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68af41698e14833397c86d36af5002db