### PR TITLE
Fix template string in cozy chief v2.81

### DIFF
--- a/cozy_settlement/cozy_chief_v2_81.html
+++ b/cozy_settlement/cozy_chief_v2_81.html
@@ -370,7 +370,7 @@ mapEl.addEventListener('click',e=>{
   const cell=S.tiles[y][x];
   if(cell.res){
     const n=NODES.find(n=>n.k===cell.res);
-    $('#planner').innerHTML = `${n.em} <b>${n.k}</b><br><span class="small">Yield: ${Object.entries(n.gain).map(([k,v])=>\`${v} ${EM[k]}\`).join(', ')}</span>`;
+    $('#planner').innerHTML = `${n.em} <b>${n.k}</b><br><span class="small">Yield: ${Object.entries(n.gain).map(([k,v])=>`${v} ${EM[k]}`).join(', ')}</span>`;
   } else {
     $('#planner').textContent='Select a building to enter placement mode, then click a tile on the map.';
   }


### PR DESCRIPTION
## Summary
- fix invalid template literal in map tile click handler that broke resource display and build options in v2.81

## Testing
- `node --check /tmp/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68af62caaab883338f6e7b30300657e9