### PR TITLE
feat: show tier progress and control population growth

### DIFF
--- a/cozy_settlement/cozy_chief_v2_81.html
+++ b/cozy_settlement/cozy_chief_v2_81.html
@@ -73,6 +73,7 @@ h2{margin:4px 0 8px; font-size:18px}
   <div class="row" style="gap:14px; margin-top:6px">
     <span class="pill">Leader: <b>Cozy Chief</b></span>
     <span class="pill">Tier <b id="tier">Hamlet I</b></span>
+    <span id="tierNext" class="small"></span>
     <span class="pill">Day <b id="day">1</b></span>
     <span class="pill">Season <b id="season">Spring</b></span>
     <span class="pill">Time <b id="clock">06:00</b></span>
@@ -100,6 +101,7 @@ h2{margin:4px 0 8px; font-size:18px}
       <button id="gStone" class="btn">🗿 Scavenge Stone<br><span class="small">+3 stone · 5s</span></button>
       <button id="gClay" class="btn">🧱 Dig Clay<br><span class="small">+3 clay · 5s</span></button>
       <button id="gFlax" class="btn">🌿 Gather Flax<br><span class="small">+2 flax · 6s</span></button>
+      <button id="recruit" class="btn">👪 Recruit Villager<br><span class="small">-30 food · 10s</span></button>
     </div>
     <h2 style="margin-top:10px">Build</h2>
     <div id="buildList"></div>
@@ -258,6 +260,7 @@ const S={
   mods:{allMult:1, woodhutMult:1, bakeryGold:1, bakeryFoodUse:1, innCulture:1, cottageBonus:0, mineDiscount:0, stoneForage:1, toolBonus:false},
   timers:{chief:0, quarry:0},
 };
+let lastPop=Math.floor(S.res.pop||0);
 BUILD.forEach(b=>S.b[b.k]=0);
 for(let y=0;y<WORLD_H;y++){ const row=[]; for(let x=0;x<WORLD_W;x++){ row.push({b:null,res:null}); } S.tiles.push(row); }
 function scatterNodes(){
@@ -271,7 +274,9 @@ function buildResourceRow(){
   const row=$('#resRow'); row.innerHTML='';
   RES.forEach(k=>{
     const pill=document.createElement('span'); pill.className='pill';
-    pill.innerHTML = `${EM[k]} <b id="r_${k}">${Math.floor(S.res[k]||0)}</b> <span class="small" style="margin-left:4px">${k}</span>`;
+    const v = S.res[k]||0;
+    const disp = k==='pop' ? v.toFixed(1) : Math.floor(v);
+    pill.innerHTML = `${EM[k]} <b id="r_${k}">${disp}</b> <span class="small" style="margin-left:4px">${k}</span>`;
     row.appendChild(pill);
   });
 }
@@ -437,8 +442,18 @@ mini.parentElement.addEventListener('click',e=>{
 
 // ===== gameplay
 function updateResAndMeta(){
-  RES.forEach(k=>$('#r_'+k).textContent=Math.floor(S.res[k]||0));
-  $('#tier').textContent=TIERS[S.tier].name; $('#day').textContent=S.day;
+  RES.forEach(k=>{
+    const v=S.res[k]||0;
+    const disp = k==='pop' ? v.toFixed(1) : Math.floor(v);
+    $('#r_'+k).textContent=disp;
+  });
+  $('#tier').textContent=TIERS[S.tier].name;
+  const nxt=TIERS[S.tier+1];
+  if(nxt){
+    const parts=Object.entries(nxt.need).map(([k,v])=>`${Math.floor(S.res[k]||0)}/${v} ${k}`);
+    $('#tierNext').textContent='→ '+nxt.name+': '+parts.join(', ');
+  } else $('#tierNext').textContent='';
+  $('#day').textContent=S.day;
   $('#season').textContent=SEASONS[S.season].name;
   const h=Math.floor(S.secs/60)%24, m=Math.floor(S.secs%60);
   $('#clock').textContent = String(h).padStart(2,'0')+':'+String(m).padStart(2,'0');
@@ -488,7 +503,12 @@ function produce(dtMinutes){
 
   // Pop growth & food
   const spare=(S.res.housing||0)-(S.res.pop||0);
-  if(spare>0 && S.res.food>20) S.res.pop = Math.min(S.res.pop + 0.01*dt, S.res.housing);
+  if(spare>0 && S.res.food>20){
+    const mult = Math.max(0,1+(S.happy-100)/100);
+    S.res.pop = Math.min(S.res.pop + 0.01*mult*dt, S.res.housing);
+    const cur=Math.floor(S.res.pop);
+    while(lastPop<cur){ lastPop++; log("New villager arrived (population: "+lastPop+")."); }
+  }
   const eat=Math.min(S.res.food, (S.res.pop*0.02)*dt); S.res.food -= eat;
   if(S.res.food<5) S.happy -= 0.05*dt; else S.happy += 0.02*dt;
   S.happy = clamp(S.happy, 50, 130);
@@ -614,6 +634,18 @@ $('#gFood').onclick=e=>{ gain({food:5}); cooldown(e.currentTarget,3000); log("Pi
 $('#gStone').onclick=e=>{ gain({stone:3}); cooldown(e.currentTarget,5000); log("Scavenged stone."); };
 $('#gClay').onclick=e=>{ gain({clay:3}); cooldown(e.currentTarget,5000); log("Waded the creek for clay."); };
 $('#gFlax').onclick=e=>{ gain({flax:2}); cooldown(e.currentTarget,6000); log("Collected flax stalks."); };
+$('#recruit').onclick=e=>{
+  if(S.res.food>=30 && (S.res.housing||0)>S.res.pop){
+    S.res.food-=30;
+    S.res.pop+=1;
+    lastPop=Math.floor(S.res.pop);
+    log("New villager arrived (population: "+lastPop+").");
+    cooldown(e.currentTarget,10000);
+    updateResAndMeta(); updateBuildButtons();
+  } else {
+    log("Need food and housing to recruit.");
+  }
+};
 $('#reset').onclick=()=>{ if(confirm("Reset?")) location.reload(); };
 $('#speed').onchange=e=>{ S.speed=parseFloat(e.target.value||'1'); };
 


### PR DESCRIPTION
## Summary
- display next-tier requirements and current progress next to Tier indicator
- show population with decimals, log each new villager, and tie growth rate to happiness
- add Recruit action to spend food for extra population growth

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af7d972f748333b95f6cd9ce14c3df