### PR TITLE
Define endCooldown for action button

### DIFF
--- a/cozy_settlement/cozy_chief_v2_84.html
+++ b/cozy_settlement/cozy_chief_v2_84.html
@@ -1459,7 +1459,25 @@ function gain(o){ Object.entries(o).forEach(([k,v])=>{
   let add=v; if(k==='stone') add = Math.round(v*(S.mods.stoneForage||1));
   S.res[k]=(S.res[k]||0)+add;
 }); updateResAndMeta(); updateBuildButtons(); }
-function cooldown(btn,ms){ btn.disabled=true; btn.dataset.cd='1'; const base=btn.innerHTML; let t=ms/1000; const id=setInterval(()=>{ t--; btn.innerHTML=base.split('<br>')[0]+`<br><span class="small">${t}s</span>`; if(t<=0){ clearInterval(id); btn.innerHTML=base; btn.dataset.cd='0'; updateActionButtons(); }},1000); }
+function cooldown(btn,ms){
+  btn.disabled=true;
+  btn.dataset.cd='1';
+  const base=btn.innerHTML;
+  let t=ms/1000;
+  btn.endCooldown=()=>{
+    btn.innerHTML=base;
+    btn.dataset.cd='0';
+    updateActionButtons();
+  };
+  const id=setInterval(()=>{
+    t--;
+    btn.innerHTML=base.split('<br>')[0]+`<br><span class="small">${t}s</span>`;
+    if(t<=0){
+      clearInterval(id);
+      btn.endCooldown();
+    }
+  },1000);
+}
 function collectNode(type,gainObj,cd,msg,btn){
   const cell=S.tiles[S.avatar.y][S.avatar.x];
   if(!cell.res || cell.res.k!==type){ log('Nothing to gather here.'); return; }


### PR DESCRIPTION
## Summary
- ensure action buttons include an `endCooldown` handler
- fix gather resource buttons failing with `this.endCooldown is not a function`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bada587c8333825635db04fe2364