### PR TITLE
Ensure game loop starts when entering CyberScorch battlefield

### DIFF
--- a/cyberscorched/cyberscorch.html
+++ b/cyberscorched/cyberscorch.html
@@ -429,9 +429,13 @@ function setupRound(){
 $("#continueBtn").addEventListener("click", ()=>{
   preRound.classList.add("hidden");
   gamewrap.classList.remove("hidden");
+  // Begin active play and kick off the main loop
+  // Previously the round transitioned to the play phase and drew a single
+  // frame, but the animation/update loop never started which left the game
+  // unresponsive.  Starting with `step()` initializes the loop so input and
+  // projectile physics run as expected.
   state.phase="play";
-  draw();
-  updateHUD();
+  step();
 });
 
 function makeTerrain(){


### PR DESCRIPTION
## Summary
- Start the main game loop when leaving the pre-round screen so controls and projectiles work

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bc1936248333b2a650020055f53d