### PR TITLE
Ensure Cyberscorched round starts the animation loop

### DIFF
--- a/cyberscorched/cyberscorch.html
+++ b/cyberscorched/cyberscorch.html
@@ -429,13 +429,11 @@ function setupRound(){
 $("#continueBtn").addEventListener("click", ()=>{
   preRound.classList.add("hidden");
   gamewrap.classList.remove("hidden");
-  // Begin active play and kick off the main loop
-  // Previously the round transitioned to the play phase and drew a single
-  // frame, but the animation/update loop never started which left the game
-  // unresponsive.  Starting with `step()` initializes the loop so input and
-  // projectile physics run as expected.
+  // Begin active play and kick off the main loop. Using
+  // `requestAnimationFrame` ensures the first update happens on the next
+  // frame and prevents the game from stalling before controls become active.
   state.phase="play";
-  step();
+  requestAnimationFrame(step);
 });
 
 function makeTerrain(){


### PR DESCRIPTION
## Summary
- kick off the game loop using `requestAnimationFrame` when entering the battlefield so controls respond immediately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c79110a483338a975f898aef1992