### PR TITLE
Add victory status pill to Cozy Chief

### DIFF
--- a/cozy_settlement/cozy_chief_v2_84.html
+++ b/cozy_settlement/cozy_chief_v2_84.html
@@ -106,6 +106,7 @@ h2{margin:4px 0 8px; font-size:18px}
     <span class="pill">Time <b id="clock">06:00</b></span>
     <span class="pill">Happiness <b id="happy">100%</b></span>
     <span class="pill" id="heroBadge" style="display:none">Hero: <b id="heroTime">00:00</b></span>
+    <span id="victoryPill" class="pill" style="display:none">Victory: <b id="victoryText"></b></span>
     <label class="pill">Speed
       <select id="speed" class="select">
         <option value="0">Pause</option>


### PR DESCRIPTION
## Summary
- Show victory status in Cozy Chief's header to avoid missing-element errors

## Testing
- `node /tmp/test_updateRes.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ccbdd7648333ba88bedb1309f530