### PR TITLE
Show sign on policy percentage modifiers

### DIFF
--- a/cozy_settlement/cozy_chief_v2_84.html
+++ b/cozy_settlement/cozy_chief_v2_84.html
@@ -861,7 +861,7 @@ function updateResAndMeta(){
   if(S.won){ vp.style.display='inline-block'; vt.textContent=S.won; } else { vp.style.display='none'; }
   // Policies panel
   const pol=$('#policies'); if(pol){
-    const pct=v=>((v-1)*100).toFixed(1)+(v>=1?'%':'%');
+    const pct=v=>{const p=(v-1)*100; return (p>0?'+':'')+p.toFixed(1)+'%';};
     pol.innerHTML = [
       `Production: <b>${pct(S.policy.prod||1)}</b>`,
       `Knowledge: <b>${pct(S.policy.knowledge||1)}</b>`,
@@ -871,7 +871,7 @@ function updateResAndMeta(){
     ].join('<br>');
   }
   const gsum=$('#govPolSummary'); if(gsum){
-    const polPct = (k)=>(((S.policy[k]||1)-1)*100).toFixed(0)+'%';
+    const polPct = (k)=>{const p=(S.policy[k]||1)-1; return (p>0?'+':'')+(p*100).toFixed(0)+'%';};
     gsum.textContent = `Gov: ${S.gov||'None'} — Policy: Prod ${polPct('prod')}, Kn ${polPct('knowledge')}, Gold ${polPct('gold')}, Cult ${polPct('culture')}, Faith ${polPct('faith')}`;
   }
 }


### PR DESCRIPTION
## Summary
- Prefix `+` or `-` on policy percentage modifiers so bonuses and penalties are clear
- Apply sign formatting to policy summary text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ccc1f3b4833380cd4037a7a16ddf