### PR TITLE
fix: diversify terrain and enhance wood yields

### DIFF
--- a/cozy_settlement/cozy_chief_v2_84.html
+++ b/cozy_settlement/cozy_chief_v2_84.html
@@ -405,8 +405,9 @@ const TERRAIN=[
 // simple deterministic hash for consistent noise per tile
 function noise2d(x,y){
   let s=x*374761393 + y*668265263 + seed*31;
-  s=(s^(s>>13))*1274126177;
-  return ((s^(s>>16))>>>0)/4294967296;
+  s=(s^(s>>>13))*1274126177;
+  // mask to 31 bits to avoid losing the top bit, then scale to [0,1)
+  return (((s^(s>>>16)) & 0x7fffffff) / 0x80000000);
 }
 let oceanWidths=[];
 const OCEAN_MAX_DEPTH=3+(rng()*3|0);
@@ -453,6 +454,28 @@ function addRivers(){
   }
 }
 
+function clusterForests(iter=2){
+  const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+  for(let t=0;t<iter;t++){
+    const copy=S.tiles.map(row=>row.map(c=>c.terrain));
+    for(let y=0;y<WORLD_H;y++){
+      for(let x=0;x<WORLD_W;x++){
+        const cur=copy[y][x];
+        if(cur==='water' || cur==='hill') continue;
+        let f=0;
+        for(const [dx,dy] of dirs){
+          const nx=x+dx, ny=y+dy;
+          if(nx>=0&&ny>=0&&nx<WORLD_W&&ny<WORLD_H){
+            if(copy[ny][nx]==='forest') f++;
+          }
+        }
+        if(cur==='plains' && f>=3) S.tiles[y][x].terrain='forest';
+        else if(cur==='forest' && f<=1) S.tiles[y][x].terrain='plains';
+      }
+    }
+  }
+}
+
 function smoothBiomes(iter=1){
   const dirs=[[1,0],[-1,0],[0,1],[0,-1],[1,1],[1,-1],[-1,1],[-1,-1]];
   for(let t=0;t<iter;t++){
@@ -495,7 +518,7 @@ const S={
 let lastPop=Math.floor(S.res.pop||0);
 BUILD.forEach(b=>S.b[b.k]=0);
 for(let y=0;y<WORLD_H;y++){ const row=[]; for(let x=0;x<WORLD_W;x++){ row.push({b:null,res:null,terrain:randTerrain(x,y)}); } S.tiles.push(row); }
-addOcean(); addLake(); addRivers(); smoothBiomes(0);
+addOcean(); addLake(); addRivers(); clusterForests();
 let critters=[];
 function randAmt(k){
   const n=NODES.find(n=>n.k===k);
@@ -959,6 +982,7 @@ function prodMult(b){
   if(b.k==='woodhut' || b.k==='lumbermill'){
     m*=S.mods.woodhutMult;
     if(S.terrain.woodTotal>0){ m *= (1 + 0.1 * (S.terrain.woodOnForest / S.terrain.woodTotal)); }
+    m*=treeAdjMult(b.k);
   }
   if(b.k==='quarry'){
     if(S.terrain.quarryTotal>0){ m *= (1 + 0.1 * (S.terrain.quarryOnHill / S.terrain.quarryTotal)); }
@@ -989,6 +1013,27 @@ function countAdj(x,y,type){
   for(const [dx,dy] of dirs){ const nx=x+dx, ny=y+dy; if(nx>=0&&ny>=0&&nx<WORLD_W&&ny<WORLD_H){ if(S.tiles[ny][nx].b===type) c++; } }
   return c;
 }
+
+function treeAdjMult(type){
+  let count=0, adj=0;
+  for(let y=0;y<WORLD_H;y++){
+    for(let x=0;x<WORLD_W;x++){
+      if(S.tiles[y][x].b===type){
+        count++;
+        const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+        for(const [dx,dy] of dirs){
+          const nx=x+dx, ny=y+dy;
+          if(nx>=0&&ny>=0&&nx<WORLD_W&&ny<WORLD_H){
+            const r=S.tiles[ny][nx].res;
+            if(r && r.k==='tree' && (r.left||0)>0){ adj++; break; }
+          }
+        }
+      }
+    }
+  }
+  return count? (1 + adj/count) : 1;
+}
+
 function avgAnimalsNear(type, r){
   let count=0, total=0;
   for(let y=0;y<WORLD_H;y++){
@@ -1547,7 +1592,8 @@ function collectNode(type,gainObj,cd,msg,btn){
   if(!cell || !cell.res || cell.res.k!==type){ log('Nothing to gather here.'); return; }
   cooldown(btn,cd);
   const key=Object.keys(gainObj)[0];
-  const per=gainObj[key];
+  let per=gainObj[key];
+  if(type==='tree' && cell.terrain==='forest') per*=2;
   const amt=Math.min(per, cell.res.left||0);
   gain({[key]:amt});
   cell.res.left = Math.max(0, (cell.res.left||0) - amt);


### PR DESCRIPTION
## Summary
- fix noise function so hills can generate
- add forest clustering and call it during world setup
- boost wood from forest trees and double wood building output near trees

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0db03fda883338155f5ad508164c5